### PR TITLE
Fix wrongly named variable

### DIFF
--- a/mt_metrics_eval/wmt22_metrics.ipynb
+++ b/mt_metrics_eval/wmt22_metrics.ipynb
@@ -50,7 +50,7 @@
         "  \"\"\"Return an attribute: {values} map for a collection of task names.\"\"\"\n",
         "  attr_val_dict = {}\n",
         "  for name in tasknames:\n",
-        "    for k, v in task_to_dict(taskname):\n",
+        "    for k, v in task_to_dict(name):\n",
         "      if k not in attr_val_dict:\n",
         "        attr_val_dict[k] = set()\n",
         "      attr_val_dict[k].add(v)\n",


### PR DESCRIPTION
This doesn't affect the results as this method is not used at the end. However, without this fix, it takes global variable "taskname"